### PR TITLE
optional dependencies

### DIFF
--- a/src/main/java/fermiumbooter/annotations/MixinConfig.java
+++ b/src/main/java/fermiumbooter/annotations/MixinConfig.java
@@ -39,8 +39,8 @@ public @interface MixinConfig {
 	 * If checks fail a specific warning will be logged and a general warning will display on screen
 	 * modid: ModID of the target mod
 	 * desired: Whether the target mod is desired - true is treated as a dependency, false is treated as an incompatibility
-	 * required: true is treated as a hard dependency/incompatibility, false as an optional dependency / optional incompatibility. Optional failed compat checks will not log/render warnings
 	 * disableMixin: If the check fails, true will disable the annotated mixin(s), false will only log a warning
+	 * warnIngame: If the check fails, true will render a warning ingame, false will only log a warning
 	 * reason: Reasoning to print to the log to give additional context to the relation if the check fails
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
@@ -49,8 +49,8 @@ public @interface MixinConfig {
 	@interface CompatHandling {
 		String modid();
 		boolean desired();
-		boolean required();
 		boolean disableMixin() default true;
+		boolean warnIngame() default true;
 		String reason() default "Undefined";
 	}
 	

--- a/src/main/java/fermiumbooter/annotations/MixinConfig.java
+++ b/src/main/java/fermiumbooter/annotations/MixinConfig.java
@@ -38,7 +38,8 @@ public @interface MixinConfig {
 	 * Provides additional modID-based compatibility handling for fields annotated by @MixinToggle
 	 * If checks fail a specific warning will be logged and a general warning will display on screen
 	 * modid: ModID of the target mod
-	 * desired: If the target mod is desired, true is treated as a dependency, false is treated as an incompatibility
+	 * desired: Whether the target mod is desired - true is treated as a dependency, false is treated as an incompatibility
+	 * required: true is treated as a hard dependency/incompatibility, false as an optional dependency / optional incompatibility. Optional failed compat checks will not log/render warnings
 	 * disableMixin: If the check fails, true will disable the annotated mixin(s), false will only log a warning
 	 * reason: Reasoning to print to the log to give additional context to the relation if the check fails
 	 */
@@ -48,6 +49,7 @@ public @interface MixinConfig {
 	@interface CompatHandling {
 		String modid();
 		boolean desired();
+		boolean required();
 		boolean disableMixin() default true;
 		String reason() default "Undefined";
 	}

--- a/src/main/java/fermiumbooter/util/ASMClassVisitor.java
+++ b/src/main/java/fermiumbooter/util/ASMClassVisitor.java
@@ -198,14 +198,14 @@ public class ASMClassVisitor extends ClassVisitor {
 					if(modid == null || modid.isEmpty()) continue;
 					Boolean desired = (Boolean)compatHandlingVisitor.getValues().get("desired");
 					if(desired == null) desired = true;
-					Boolean required = (Boolean)compatHandlingVisitor.getValues().get("required");
-					if(required == null) required = true;
 					Boolean disableMixin = (Boolean)compatHandlingVisitor.getValues().get("disableMixin");
 					if(disableMixin == null) disableMixin = true;
+					Boolean warnIngame = (Boolean)compatHandlingVisitor.getValues().get("warnIngame");
+					if(warnIngame == null) warnIngame = true;
 					String reason = (String)compatHandlingVisitor.getValues().get("reason");
 					if(reason == null) reason = "";
 					
-					this.compatHandlingAnnotations.add(new CompatHandlingAnnotation(modid, desired, required, disableMixin, reason));
+					this.compatHandlingAnnotations.add(new CompatHandlingAnnotation(modid, desired, disableMixin, warnIngame, reason));
 				}
 			}
 		}
@@ -215,15 +215,15 @@ public class ASMClassVisitor extends ClassVisitor {
 		
 		public final String modid;
 		public final boolean desired;
-		public final boolean required;
 		public final boolean disableMixin;
+		public final boolean warnIngame;
 		public final String reason;
 		
-		public CompatHandlingAnnotation(String modid, boolean desired, boolean required, boolean disableMixin, String reason) {
+		public CompatHandlingAnnotation(String modid, boolean desired, boolean disableMixin, boolean warnIngame, String reason) {
 			this.modid = modid;
 			this.desired = desired;
-			this.required = required;
 			this.disableMixin = disableMixin;
+			this.warnIngame = warnIngame;
 			this.reason = reason;
 		}
 	}

--- a/src/main/java/fermiumbooter/util/ASMClassVisitor.java
+++ b/src/main/java/fermiumbooter/util/ASMClassVisitor.java
@@ -198,12 +198,14 @@ public class ASMClassVisitor extends ClassVisitor {
 					if(modid == null || modid.isEmpty()) continue;
 					Boolean desired = (Boolean)compatHandlingVisitor.getValues().get("desired");
 					if(desired == null) desired = true;
+					Boolean required = (Boolean)compatHandlingVisitor.getValues().get("required");
+					if(required == null) required = true;
 					Boolean disableMixin = (Boolean)compatHandlingVisitor.getValues().get("disableMixin");
 					if(disableMixin == null) disableMixin = true;
 					String reason = (String)compatHandlingVisitor.getValues().get("reason");
 					if(reason == null) reason = "";
 					
-					this.compatHandlingAnnotations.add(new CompatHandlingAnnotation(modid, desired, disableMixin, reason));
+					this.compatHandlingAnnotations.add(new CompatHandlingAnnotation(modid, desired, required, disableMixin, reason));
 				}
 			}
 		}
@@ -213,12 +215,14 @@ public class ASMClassVisitor extends ClassVisitor {
 		
 		public final String modid;
 		public final boolean desired;
+		public final boolean required;
 		public final boolean disableMixin;
 		public final String reason;
 		
-		public CompatHandlingAnnotation(String modid, boolean desired, boolean disableMixin, String reason) {
+		public CompatHandlingAnnotation(String modid, boolean desired, boolean required, boolean disableMixin, String reason) {
 			this.modid = modid;
 			this.desired = desired;
+			this.required = required;
 			this.disableMixin = disableMixin;
 			this.reason = reason;
 		}

--- a/src/main/java/fermiumbooter/util/FermiumJarScanner.java
+++ b/src/main/java/fermiumbooter/util/FermiumJarScanner.java
@@ -195,15 +195,17 @@ public abstract class FermiumJarScanner {
 				if(!skipCompatHandlingChecks()) {
 					for(ASMClassVisitor.CompatHandlingAnnotation compatAnno : parsedField.compatHandlingAnnotations) {
 						if(compatAnno.desired != isModPresent(compatAnno.modid)) {
-							warningCount++;
-							if(compatAnno.disableMixin) {
+							if(compatAnno.disableMixin)
 								shouldApply = false;
-								LOGGER.log(Level.ERROR, "FermiumMixinConfig config {} from {} disabled as incompatible {} {}: {}.",
-										   parsedField.configFieldName, mixinConfigName, (compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
-							}
-							else {
-								LOGGER.log(Level.WARN, "FermiumMixinConfig config {} from {} may have issues {} {}: {}.",
-										   parsedField.configFieldName, mixinConfigName, (compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
+
+							if(compatAnno.required) {
+								warningCount++;
+								if (compatAnno.disableMixin)
+									LOGGER.log(Level.ERROR, "FermiumMixinConfig config {} from {} disabled as incompatible {} {}: {}.",
+											parsedField.configFieldName, mixinConfigName, (compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
+								else
+									LOGGER.log(Level.WARN, "FermiumMixinConfig config {} from {} may have issues {} {}: {}.",
+											parsedField.configFieldName, mixinConfigName, (compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
 							}
 						}
 					}

--- a/src/main/java/fermiumbooter/util/FermiumJarScanner.java
+++ b/src/main/java/fermiumbooter/util/FermiumJarScanner.java
@@ -195,17 +195,15 @@ public abstract class FermiumJarScanner {
 				if(!skipCompatHandlingChecks()) {
 					for(ASMClassVisitor.CompatHandlingAnnotation compatAnno : parsedField.compatHandlingAnnotations) {
 						if(compatAnno.desired != isModPresent(compatAnno.modid)) {
-							if(compatAnno.disableMixin)
+							if(compatAnno.warnIngame) warningCount++;
+							if(compatAnno.disableMixin) {
 								shouldApply = false;
-
-							if(compatAnno.required) {
-								warningCount++;
-								if (compatAnno.disableMixin)
-									LOGGER.log(Level.ERROR, "FermiumMixinConfig config {} from {} disabled as incompatible {} {}: {}.",
-											parsedField.configFieldName, mixinConfigName, (compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
-								else
-									LOGGER.log(Level.WARN, "FermiumMixinConfig config {} from {} may have issues {} {}: {}.",
-											parsedField.configFieldName, mixinConfigName, (compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
+								LOGGER.log(Level.ERROR, "FermiumMixinConfig config {} from {} disabled as incompatible {} {}: {}.", parsedField.configFieldName, mixinConfigName, (
+										compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
+							}
+							else {
+								LOGGER.log(Level.WARN, "FermiumMixinConfig config {} from {} may have issues {} {}: {}.", parsedField.configFieldName, mixinConfigName, (
+										compatAnno.desired ? "without" : "with"), compatAnno.modid, compatAnno.reason);
 							}
 						}
 					}


### PR DESCRIPTION
its a bit bloaty together with disableMixin and desired, an enum for the state would be better. but this works and is backwards compatible

idea is that mixins with optional dependencies should apply automatically and silently, without a warning when the mod isnt present (or is present for undesired mods)